### PR TITLE
Gobin/debug/signal func

### DIFF
--- a/Final Project_Files/Thumb2_Programs/stdlib.s
+++ b/Final Project_Files/Thumb2_Programs/stdlib.s
@@ -185,6 +185,9 @@ _signal
 		;issue supervisor call
         SVC     #0x2
 		
+		; move return value from R5 to R0
+		MOV		R0, R5
+		
 		; resume registers/return to caller
 		POP		{R4-R11}
 		BX		LR

--- a/Final Project_Files/Thumb2_Programs/timer.s
+++ b/Final Project_Files/Thumb2_Programs/timer.s
@@ -109,22 +109,26 @@ timer_update_done
 ; void* signal_handler( int signum, void* handler )
 	    EXPORT	_signal_handler
 _signal_handler
-	;; Implement by yourself
 	
-		 ; Check if signal is SIGALRM (14)
-        CMP     R0, #14              ; Compare with SIGALRM value
+		; Check if signal is SIGALRM (14)
+		LDR		R2, =SIGALRM
+        CMP     R0, R2               ; Compare with SIGALRM value
         BNE     not_alarm            ; If not SIGALRM, skip
 
         ; Get address where user handler is stored
-        LDR     R2, =0x20007B84      ; Load USR_HANDLER address
+        LDR     R2, =USR_HANDLER      ; Load USR_HANDLER address
 
-        ; Store current handler in R0 to return it
-        LDR     R0, [R2]             ; Load current handler address
+		; load previous value of USR_HANDLER in R3
+		LDR		R3, [R2]
 
-        ; Store new handler from R1
-        STR     R1, [R2]             ; Store new handler address
+        ; store new handler at address USR_HANDLER
+        STR     R1, [R2]
 
-        BX      LR                   ; Return with old handler in R0	
+        ; move previous user handler to R0 (return register)
+		MOV		R0, R3
+
+        BX      LR                   ; Return with old handler in R0
+
 not_alarm
         MOV     R0, #0               ; Return 0 for unsupported signals
         BX      LR                   ; Return to caller		

--- a/RTE/Device/TM4C129XNCZAD/startup_TM4C129.s
+++ b/RTE/Device/TM4C129XNCZAD/startup_TM4C129.s
@@ -286,8 +286,11 @@ SVC_Handler     PROC
 
 				POP     {R4-R11, LR}                   ; Restore registers
 				
-				; move return value in R3, to R4
+				; move return value in R3 to R4 (for _kalloc calls)
 				MOV		R4, R3
+				
+				; move return value in R0 to R5 (for _signal_handler calls)
+				MOV		R5, R0
 				
 				BX		LR
 				


### PR DESCRIPTION
dont think we were saving previous USR_HANDLER before storing the new USR_HANDLR

![image](https://github.com/user-attachments/assets/64a4fae9-5012-4dfd-9662-e1001c2a750c)
_signal_handler function requires previous USR_HANDLER value to be saved and returned via R0. pretty sure it does that now